### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -71,7 +71,7 @@ def scan_all_files(log_data):
         for filename in flist:
             count = count + 1
             if (count%1000==0):
-                print ("Processing file %s000th"%(count/1000,))
+                print ("Processing file {0!s}000th".format(count/1000))
 
             with open (mypath + "/" + filename, "r") as myfile:
                 # Read the file
@@ -117,11 +117,11 @@ def scan_all_files(log_data):
                                'transmitterRegion':transmitterRegion,
                                'digitalServices':digitalServices,
                                'channels':channels}
-                    rowStr = "%s,%s,%s,%s"%(row['code'],row['signalQuality'],row['transmitterName'],row['transmitterRegion'],)
+                    rowStr = "{0!s},{1!s},{2!s},{3!s}".format(row['code'], row['signalQuality'], row['transmitterName'], row['transmitterRegion'])
                     for service in DIGITAL_SEVICES:
-                        rowStr =rowStr + ',%d' % (int(service in row['digitalServices']),)
+                        rowStr =rowStr + ',{0:d}'.format(int(service in row['digitalServices']))
                     for channel in CHANNELS:
-                        rowStr =rowStr + ',%d' % (int(channel in row['channels']),)
+                        rowStr =rowStr + ',{0:d}'.format(int(channel in row['channels']))
                     my_output_file.write(rowStr + "\n")
 
 print "------------FIRST PHASE----------------"
@@ -132,11 +132,11 @@ DIGITAL_SEVICES = sorted(DIGITAL_SEVICES)
 CHANNELS = sorted(CHANNELS)
 
 # Genearate the column name list
-headerStr = "%s,%s,%s,%s"%('postal.code','quality.terrestrial.tv.signal','transmitter.name','transmitter.region',)
+headerStr = "{0!s},{1!s},{2!s},{3!s}".format('postal.code', 'quality.terrestrial.tv.signal', 'transmitter.name', 'transmitter.region')
 for service in DIGITAL_SEVICES:
-    headerStr =headerStr + ',service.%s' % (service,)
+    headerStr =headerStr + ',service.{0!s}'.format(service)
 for channel in CHANNELS:
-    headerStr =headerStr + ',channel.%s' % (channel,)
+    headerStr =headerStr + ',channel.{0!s}'.format(channel)
 my_output_file.write(headerStr + "\n")
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:digitaltv-coverage-in-uk?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:digitaltv-coverage-in-uk?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
